### PR TITLE
Add loom development dependencies to test runtime classpath

### DIFF
--- a/src/main/java/org/quiltmc/loom/configuration/CompileConfiguration.java
+++ b/src/main/java/org/quiltmc/loom/configuration/CompileConfiguration.java
@@ -97,6 +97,7 @@ public final class CompileConfiguration {
 		extendsFrom(JavaPlugin.IMPLEMENTATION_CONFIGURATION_NAME, Constants.Configurations.MAPPINGS_FINAL, project);
 
 		extendsFrom(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, project);
+		extendsFrom(JavaPlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME, Constants.Configurations.LOOM_DEVELOPMENT_DEPENDENCIES, project);
 	}
 
 	public static void configureCompile(Project p) {


### PR DESCRIPTION
Currently, `loomDevelopmentDependencies` is added to `runtimeClasspath`, but not to `testRuntimeClasspath`, causing `ClassNotFoundException: net.fabricmc.devlaunchinjector.Main` when trying to run Minecraft from Intellij with the test module (FabricMC/fabric-loom#385). This PR solves this issue.