### PR TITLE
Fix interface injection of inner class interfaces

### DIFF
--- a/patches/0007-Fix-interface-injection-of-inner-class-interfaces.patch
+++ b/patches/0007-Fix-interface-injection-of-inner-class-interfaces.patch
@@ -1,0 +1,121 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zml <zml@stellardrift.ca>
+Date: Sun, 8 Jan 2023 21:44:14 -0800
+Subject: [PATCH] Fix interface injection of inner class interfaces
+
+
+diff --git a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+index 4c31146968ab7e6cd3f895a87f6e0695b1868620..4af6494b672a60ee9c69ebaa3a3939f9adc2c894 100644
+--- a/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
++++ b/src/main/java/net/fabricmc/loom/configuration/ifaceinject/InterfaceInjectionProcessor.java
+@@ -33,6 +33,7 @@ import java.nio.file.Path;
+ import java.util.ArrayList;
+ import java.util.Collections;
+ import java.util.HashMap;
++import java.util.HashSet;
+ import java.util.LinkedHashSet;
+ import java.util.List;
+ import java.util.Map;
+@@ -49,6 +50,7 @@ import org.gradle.api.tasks.SourceSet;
+ import org.objectweb.asm.ClassReader;
+ import org.objectweb.asm.ClassVisitor;
+ import org.objectweb.asm.ClassWriter;
++import org.objectweb.asm.Opcodes;
+ import org.objectweb.asm.commons.Remapper;
+ 
+ import net.fabricmc.loom.LoomGradleExtension;
+@@ -70,6 +72,7 @@ import net.fabricmc.tinyremapper.TinyRemapper;
+ public class InterfaceInjectionProcessor implements JarProcessor, GenerateSourcesTask.MappingsProcessor {
+ 	// Filename used to store hash of injected interfaces in processed jar file
+ 	private static final String HASH_FILENAME = "injected_interfaces.sha256";
++	private static final int INTERFACE_ACCESS = Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC | Opcodes.ACC_ABSTRACT | Opcodes.ACC_INTERFACE;
+ 
+ 	private final Map<String, List<InjectedInterface>> injectedInterfaces;
+ 	private final Project project;
+@@ -240,14 +243,18 @@ public class InterfaceInjectionProcessor implements JarProcessor, GenerateSource
+ 	}
+ 
+ 	private static String appendComment(String comment, List<InjectedInterface> injectedInterfaces) {
++		final StringBuilder commentBuilder = comment == null ? new StringBuilder() : new StringBuilder(comment);
++
+ 		for (InjectedInterface injectedInterface : injectedInterfaces) {
+-			String iiComment = "Interface {@link %s} injected by mod %s".formatted(injectedInterface.ifaceName().substring(injectedInterface.ifaceName().lastIndexOf("/") + 1), injectedInterface.modId());
++			String iiComment = "<p>Interface {@link %s} injected by mod %s</p>".formatted(injectedInterface.ifaceName().replace('/', '.').replace('$', '.'), injectedInterface.modId());
+ 
+-			if (comment == null || !comment.contains(iiComment)) {
+-				if (comment == null) {
+-					comment = iiComment;
++			if (commentBuilder.indexOf(iiComment) == -1) {
++				if (commentBuilder.isEmpty()) {
++					commentBuilder.append(iiComment);
+ 				} else {
+-					comment += "\n" + iiComment;
++					commentBuilder
++							.append('\n')
++							.append(iiComment);
+ 				}
+ 			}
+ 		}
+@@ -257,6 +264,7 @@ public class InterfaceInjectionProcessor implements JarProcessor, GenerateSource
+ 
+ 	private static class InjectingClassVisitor extends ClassVisitor {
+ 		private final List<InjectedInterface> injectedInterfaces;
++		private final Set<String> knownInnerClasses = new HashSet<>();
+ 
+ 		InjectingClassVisitor(int asmVersion, ClassWriter writer, List<InjectedInterface> injectedInterfaces) {
+ 			super(asmVersion, writer);
+@@ -289,6 +297,54 @@ public class InterfaceInjectionProcessor implements JarProcessor, GenerateSource
+ 
+ 			super.visit(version, access, name, signature, superName, modifiedInterfaces.toArray(new String[0]));
+ 		}
++
++		@Override
++		public void visitInnerClass(final String name, final String outerName, final String innerName, final int access) {
++			this.knownInnerClasses.add(name);
++			super.visitInnerClass(name, outerName, innerName, access);
++		}
++
++		@Override
++		public void visitEnd() {
++			// inject any necessary inner class entries
++			// this may produce technically incorrect bytecode cuz we don't know the actual access flags for inner class entries
++			// but it's hopefully enough to quiet some IDE errors
++			for (final InjectedInterface itf : injectedInterfaces) {
++				if (this.knownInnerClasses.contains(itf.ifaceName())) {
++					continue;
++				}
++
++				int simpleNameIdx = itf.ifaceName().lastIndexOf('/');
++				final String simpleName = simpleNameIdx == -1 ? itf.ifaceName() : itf.ifaceName().substring(simpleNameIdx + 1);
++				int lastIdx = -1;
++				int dollarIdx = -1;
++
++				// Iterate through inner class entries starting from outermost to innermost
++				while ((dollarIdx = simpleName.indexOf('$', dollarIdx + 1)) != -1) {
++					if (dollarIdx - lastIdx == 1) {
++						continue;
++					}
++
++					// Emit the inner class entry from this to the last one
++					if (lastIdx != -1) {
++						final String outerName = itf.ifaceName().substring(0, simpleNameIdx + 1 + lastIdx);
++						final String innerName = simpleName.substring(lastIdx + 1, dollarIdx);
++						super.visitInnerClass(outerName + '$' + innerName, outerName, innerName, INTERFACE_ACCESS);
++					}
++
++					lastIdx = dollarIdx;
++				}
++
++				// If we have a trailer to append
++				if (lastIdx != -1 && lastIdx != simpleName.length()) {
++					final String outerName = itf.ifaceName().substring(0, simpleNameIdx + 1 + lastIdx);
++					final String innerName = simpleName.substring(lastIdx + 1);
++					super.visitInnerClass(outerName + '$' + innerName, outerName, innerName, INTERFACE_ACCESS);
++				}
++			}
++
++			super.visitEnd();
++		}
+ 	}
+ 
+ 	private TinyRemapper createTinyRemapper() {


### PR DESCRIPTION
This is a touch ugly, but it seems to fix issues with IntelliJ's project model when inner class interfaces are injected

We have to do a whole bunch of guesswork unfortunately, since the injected interfaces are not necessarily even compiled classes when we're preparing the minecraft jar yet, but this should produce better results than before(:tm:).

I've tweaked the javadoc generation for inner classes as well, just to make the rendered javadoc a little prettier and hopefully reduce some string allocations.