### PR TITLE
fix(unpick): Add mod classpath to unpick

### DIFF
--- a/patches/0007-fix-unpick-Add-mod-classpath-to-unpick.patch
+++ b/patches/0007-fix-unpick-Add-mod-classpath-to-unpick.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: zml <zml@stellardrift.ca>
+Date: Tue, 10 Jan 2023 18:43:31 -0800
+Subject: [PATCH] fix(unpick): Add mod classpath to unpick
+
+This avoids exceptions thrown by unpick when trying to walk inheritance up
+into mod-injected interfaces, which were previously not on the classpath
+
+diff --git a/src/main/java/net/fabricmc/loom/task/UnpickJarTask.java b/src/main/java/net/fabricmc/loom/task/UnpickJarTask.java
+index 3ac72fecdf5c890ff695288b3e843feb9ab513d6..e9736bf9cbb685694bc5ccd5a6a4ae1896cd900a 100644
+--- a/src/main/java/net/fabricmc/loom/task/UnpickJarTask.java
++++ b/src/main/java/net/fabricmc/loom/task/UnpickJarTask.java
+@@ -69,6 +69,7 @@ public abstract class UnpickJarTask extends JavaExec {
+ 
+ 		getConstantJar().setFrom(getProject().getConfigurations().getByName(Constants.Configurations.MAPPING_CONSTANTS));
+ 		getUnpickClasspath().setFrom(getProject().getConfigurations().getByName(Constants.Configurations.MINECRAFT_DEPENDENCIES));
++		getUnpickClasspath().from(getProject().getConfigurations().getByName(Constants.Configurations.MOD_COMPILE_CLASSPATH_MAPPED)); // injected interfaces
+ 	}
+ 
+ 	@Override


### PR DESCRIPTION
This avoids exceptions thrown by unpick when trying to walk inheritance up into mod-injected interfaces, which were previously not on the classpath