### PR TITLE
Exclude quilt-loader-dependencies from remapped configurations

### DIFF
--- a/patches/0001-Initial-Quiltification.patch
+++ b/patches/0001-Initial-Quiltification.patch
@@ -137,7 +137,7 @@ index 71248d2d72437815aecbee42d01ee4ec62589a65..76a88fc552f9324bb9d56c57a68fd504
  
  		// Apply default plugins
 diff --git a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
-index ef9bd58ef74cc149e7010220c966bb6df2ed475c..4e57a69eacd71f9b6df5dd6566fb14d3066e9760 100644
+index 896c72df20c7f64a9e44ec5883fadb21c1e6f5cb..743a5847aaeb36968739c8c3c39da67862ec95e5 100644
 --- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
 +++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
 @@ -67,7 +67,10 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {

--- a/patches/0001-Initial-Quiltification.patch
+++ b/patches/0001-Initial-Quiltification.patch
@@ -137,7 +137,7 @@ index 71248d2d72437815aecbee42d01ee4ec62589a65..76a88fc552f9324bb9d56c57a68fd504
  
  		// Apply default plugins
 diff --git a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
-index 896c72df20c7f64a9e44ec5883fadb21c1e6f5cb..743a5847aaeb36968739c8c3c39da67862ec95e5 100644
+index ef9bd58ef74cc149e7010220c966bb6df2ed475c..4e57a69eacd71f9b6df5dd6566fb14d3066e9760 100644
 --- a/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
 +++ b/src/main/java/net/fabricmc/loom/LoomRepositoryPlugin.java
 @@ -67,7 +67,10 @@ public class LoomRepositoryPlugin implements Plugin<PluginAware> {

--- a/patches/0005-Exclude-quilt-loader-dependencies-from-remapped-conf.patch
+++ b/patches/0005-Exclude-quilt-loader-dependencies-from-remapped-conf.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Luke Bemish <lukebemish@lukebemish.dev>
+Date: Sun, 31 Mar 2024 19:32:07 -0500
+Subject: [PATCH] Exclude quilt-loader dependencies from remapped
+ configurations
+
+
+diff --git a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+index 033499915d4af1a0bb29857b58a9cf66eb883658..27e7dbbbd6aa4d254f9a6121690e329ba5bebe7a 100644
+--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
++++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+@@ -26,6 +26,7 @@ package net.fabricmc.loom.configuration;
+ 
+ import java.util.List;
+ import java.util.Locale;
++import java.util.Map;
+ import java.util.function.Function;
+ 
+ import org.gradle.api.Action;
+@@ -172,6 +173,8 @@ public final class RemapConfigurations {
+ 			extendsFrom(Constants.Configurations.MOD_COMPILE_CLASSPATH, configuration, project);
+ 		}
+ 
++		configuration.exclude(Map.of("group", "org.quiltmc", "module", "quilt-loader-dependencies"));
++
+ 		for (String outgoingConfigurationName : settings.getPublishingMode().get().outgoingConfigurations()) {
+ 			extendsFrom(outgoingConfigurationName, configuration, project);
+ 		}


### PR DESCRIPTION
Companion to QuiltMC/quilt-loader#418 -- excludes the new `quilt-loader-dependencies` module from being resolved transitively in the configurations that are remapped. I plan to backport a similar exclusion to older branches.