### PR TITLE
Exclude quilt-loader dependencies from remapped configurations - 1.2

### DIFF
--- a/patches/0007-Exclude-quilt-loader-dependencies-from-remapped-conf.patch
+++ b/patches/0007-Exclude-quilt-loader-dependencies-from-remapped-conf.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Exclude quilt-loader dependencies from remapped
 
 
 diff --git a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
-index 033499915d4af1a0bb29857b58a9cf66eb883658..1f04e10600d35069e7c376c754e6b01b4b943154 100644
+index 1428c8ee114deddb0e956cd647d44f8f0dbc12bb..6a1aeef83ee91693aa412f2fb0efaad42cdf5725 100644
 --- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
 +++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
 @@ -172,6 +172,8 @@ public final class RemapConfigurations {
  			extendsFrom(Constants.Configurations.MOD_COMPILE_CLASSPATH, configuration, project);
  		}
  
-+		configuration.exclude(Map.of("group", "org.quiltmc", "module", "quilt-loader-dependencies"));
++		configuration.exclude(java.util.Map.of("group", "org.quiltmc", "module", "quilt-loader-dependencies"));
 +
  		for (String outgoingConfigurationName : settings.getPublishingMode().get().outgoingConfigurations()) {
  			extendsFrom(outgoingConfigurationName, configuration, project);

--- a/patches/0007-Exclude-quilt-loader-dependencies-from-remapped-conf.patch
+++ b/patches/0007-Exclude-quilt-loader-dependencies-from-remapped-conf.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Luke Bemish <lukebemish@lukebemish.dev>
+Date: Thu, 18 Apr 2024 17:26:21 -0500
+Subject: [PATCH] Exclude quilt-loader dependencies from remapped
+ configurations
+
+
+diff --git a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+index 033499915d4af1a0bb29857b58a9cf66eb883658..1f04e10600d35069e7c376c754e6b01b4b943154 100644
+--- a/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
++++ b/src/main/java/net/fabricmc/loom/configuration/RemapConfigurations.java
+@@ -172,6 +172,8 @@ public final class RemapConfigurations {
+ 			extendsFrom(Constants.Configurations.MOD_COMPILE_CLASSPATH, configuration, project);
+ 		}
+ 
++		configuration.exclude(Map.of("group", "org.quiltmc", "module", "quilt-loader-dependencies"));
++
+ 		for (String outgoingConfigurationName : settings.getPublishingMode().get().outgoingConfigurations()) {
+ 			extendsFrom(outgoingConfigurationName, configuration, project);
+ 		}


### PR DESCRIPTION
Backport of #44